### PR TITLE
fix: check if hooks are provided

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -17,7 +17,7 @@ const isLocalhost = Boolean(
 
 export function register (swUrl, hooks) {
   const emit = (hook, ...args) => {
-    if (hooks[hook]) {
+    if (hooks && hooks[hook]) {
       hooks[hook](...args)
     }
   }


### PR DESCRIPTION
This fixes a small bug (`TypeError: Cannot read property 'error' of undefined`) when user does not pass any callbacks to the register function