### PR TITLE
Pass registration as argument on cached and updated event

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -51,12 +51,12 @@ function registerValidSW (swUrl, emit) {
               // the fresh content will have been added to the cache.
               // It's the perfect time to display a "New content is
               // available; please refresh." message in your web app.
-              emit('updated')
+              emit('updated', registration)
             } else {
               // At this point, everything has been precached.
               // It's the perfect time to display a
               // "Content is cached for offline use." message.
-              emit('cached')
+              emit('cached', registration)
             }
           }
         }


### PR DESCRIPTION
I'm currently working on a single page web application with offline mode. Due to the specifics of service workers, a new version of the services worker gets only activated when all tabs of the page are closed.

Several methods and ways exist to serve the new version to the user. I would implement the way where a notification will be shown to him that the page could be reloaded and the new version served. Another way would be to force the reload, but for our use case this is a bad user experience.

One way to implement the way with showing a notification is described on this page: https://developers.google.com/web/tools/workbox/guides/advanced-recipes#offer_a_page_reload_for_users

But to implement this, I need the registration as argument for the "cached" and "updated" events. Would it be possible to pass the registration as argument?