### PR TITLE
Add registered event

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,9 @@ register('/service-worker.js', {
   ready () {
     console.log('Service worker is active.')
   },
+  registered (registration) {
+    console.log('Service worker has been registered.')
+  },
   cached (registration) {
     console.log('Content has been cached for offline use.')
   },

--- a/src/index.js
+++ b/src/index.js
@@ -42,6 +42,7 @@ function registerValidSW (swUrl, emit) {
   navigator.serviceWorker
     .register(swUrl)
     .then(registration => {
+      emit('registered', registration)
       registration.onupdatefound = () => {
         const installingWorker = registration.installing
         installingWorker.onstatechange = () => {


### PR DESCRIPTION
In some use cases it would be nice to know when the service worker was registered. Especially, if the two other events (cached, updated) are not fired. This happens when the browser already has the newest assets stored in the cache.

In this case there is no possibility with this library to access the registration. With the new event, the registration gets passed immediately after the registration.