### PR TITLE
Check if there is a worker that has been previously installed

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -62,6 +62,10 @@ function registerValidSW (swUrl, emit) {
           }
         }
       }
+      // Check if there is a worker that has been previously installed but has not yet been activated
+      if (registration.waiting) {
+        emit('updated', registration)
+      }
     })
     .catch(error => {
       emit('error', error)


### PR DESCRIPTION
In a recent practice, I found that if developers use a `updated` hook to guide users to a new version, they tend to fall into a trap.
Let me explain it with the following example steps: 

1. First, the user visits our site for the first time. The service worker caches all the files for the current version A. 
2. After a while, users visited our site for a second time. At this point, the browser directly displays the contents of version A to the user because of the Service worker interception. 
3. At the same time, the browser requests sw.js from our server and is delighted to find that we had released version B, so the browser starts getting all the files for version B in the background with the new sw.js. 
4. When the browser gets all the files for version B, our library `register-service-worker` emits the `updated` hook, so we pop up a prompt on the page asking the user if they want to use the new version B. If the user chooses "yes", then we will activate the worker of version B by calling `skipWaiting`, and then automatically refresh the page with `window.location.reload`. In most cases, up to this point, everything is going the way we expect it to. 
5. Unfortunately, there are times when users choose **not** to update immediately, or they simply close our tabs. So this time we assume that the user chose to ignore our prompt. 
6. Next, the user refreshes the page. 
7. At this point, we found that our site no longer asked users if they want to use new version B, even if the worker for version B was in the `waiting` state. 


So, what's the problem? 

First, when version B is in the `waiting` state for the first time, simply refreshing the page does not activate B's worker. The reason for this is [explained in this article](https://developers.google.com/web/fundamentals/primers/service-workers/lifecycle#waiting): 

> Even if you only have one tab open to the demo, refreshing the page isn't enough to let the new version take over. This is due to how browser navigations work. When you navigate, the current page doesn't go away until the response headers have been received, and even then the current page may stay if the response has a Content-Disposition header. Because of this overlap, the current service worker is always controlling a client during a refresh.

Second, we shouldn't call `skipWaiting` before the user confirms, which is also [explained in the above article](https://developers.google.com/web/fundamentals/primers/service-workers/lifecycle#skip_the_waiting_phase): 

> Caution: skipWaiting() means that your new service worker is likely controlling pages that were loaded with an older version. This means some of your page's fetches will have been handled by your old service worker, but your new service worker will be handling subsequent fetches. If this might break things, don't use skipWaiting().

Thus, we find that in this case, when the new worker has entered the waiting *(to be activated)* state, we are supposed to go into the process of guiding the user to update. However, we can not achieve it simply by listening to a specified hook.


**IMO, is that this case should trigger the `updated` event, and that's what `updated` is supposed to do.**

In addition, this example shows what developers need to do when `updated` event does not cover the above case:
https://github.com/imyelo/pokequest-wiki/commit/023bb812585378c7a0981be33c33f404e1b92259 

What do you think? @yyx990803 