### PR TITLE
feat: emit updated event when registration.waiting was found

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -43,6 +43,10 @@ function registerValidSW (swUrl, emit) {
     .register(swUrl)
     .then(registration => {
       emit('registered', registration)
+      if (registration.waiting) {
+        emit('updated', registration)
+        return
+      }
       registration.onupdatefound = () => {
         emit('updatefound')
         const installingWorker = registration.installing


### PR DESCRIPTION
A replacement of #8. The difference is that when we found a `waiting` service worker, it means that a new service worker has been installed, so we don't need to bind `onupdatefound`.

Ref: [《How to Fix the Refresh Button When Using Service Workers》> Approach #3](https://redfin.engineering/how-to-fix-the-refresh-button-when-using-service-workers-a8e27af6df68)