### PR TITLE
small adjustments in README.md and CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,17 +29,6 @@
 
 
 
-<a name="1.5.0"></a>
-# [1.5.0](https://github.com/yyx990803/register-service-worker/compare/v1.4.1...v1.5.0) (2018-08-13)
-
-
-### Features
-
-* add "updatefound" event ([#7](https://github.com/yyx990803/register-service-worker/issues/7)) ([bee2641](https://github.com/yyx990803/register-service-worker/commit/bee2641))
-* emit updated event when registration.waiting was found ([#9](https://github.com/yyx990803/register-service-worker/issues/9)) ([937040f](https://github.com/yyx990803/register-service-worker/commit/937040f))
-
-
-
 <a name="1.4.1"></a>
 ## [1.4.1](https://github.com/yyx990803/register-service-worker/compare/v1.4.0...v1.4.1) (2018-06-18)
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ A script to simplify service worker registration with hooks for common events.
 import { register } from 'register-service-worker'
 
 register('/service-worker.js', {
-  ready () {
+  ready (registration) {
     console.log('Service worker is active.')
   },
   registered (registration) {
@@ -34,4 +34,4 @@ register('/service-worker.js', {
 })
 ```
 
-The `cached`, `updatefound` and `updated` events passes a [ServiceWorkerRegistration](https://developer.mozilla.org/en-US/docs/Web/API/ServiceWorkerRegistration) instance in their arguments.
+The `ready`, `registered`, `cached`, `updatefound` and `updated` events passes a [ServiceWorkerRegistration](https://developer.mozilla.org/en-US/docs/Web/API/ServiceWorkerRegistration) instance in their arguments.


### PR DESCRIPTION
- update `README.md`: add missing `registration` argument in hooks
- fix `CHANGELOG.md`: remove 1.5.0 duplication