### PR TITLE
fix: remove default scope from registrationOptions

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -16,7 +16,7 @@ const isLocalhost = () => Boolean(
 )
 
 export function register (swUrl, hooks = {}) {
-  const { registrationOptions = { scope: '/' }} = hooks
+  const { registrationOptions = {}} = hooks
   delete hooks.registrationOptions
 
   const emit = (hook, ...args) => {


### PR DESCRIPTION
# Motivation

Recently we have supported [registration options](https://github.com/yyx990803/register-service-worker/commit/c6f0386069296ae6bdf9df77f96a7a725286f9f5) and its default value is set to `{ scope: '/' }`, but there is a potential problem, if an user didn't pass in registrationOptions, at the same time he/she deployed his/her site at a sub directory, e.g. `vuejs.org/sub/`. he will meet a error of service worker:

> The path of the provided scope ('/') is not under the max scope allowed ('/sub/'). Adjust the scope, move the Service Worker script, or use the Service-Worker-Allowed HTTP header to allow the scope.

This is due to the service-worker.js is under `vuejs.org/sub/` but the default scope we set is equivalent to `vuejs.org/` which causes the leading out of scope. so in that case user'll need to override registrationOptions.

Actually, following the [mozilla](https://developer.mozilla.org/en-US/docs/Web/API/ServiceWorkerContainer/register):

> By default, the scope value for a service worker registration is set to the directory where the service worker script is located.

So we needn't to set the default value since the native register API will help us to do it.

---

BTW, actually I guess it should typo of the previous PR, the default value should be `./` instead of `/`. but the better is to remove it directly.

 