### PR TITLE
fix: Emit 'offline' in not localhost

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -41,6 +41,14 @@ export function register (swUrl, hooks = {}) {
   }
 }
 
+function handleError (emit, error) {
+  if (!navigator.onLine) {
+    emit('offline')
+  } else {
+    emit('error', error)
+  }
+}
+
 function registerValidSW (swUrl, emit, registrationOptions) {
   navigator.serviceWorker
     .register(swUrl, registrationOptions)
@@ -71,9 +79,7 @@ function registerValidSW (swUrl, emit, registrationOptions) {
         }
       }
     })
-    .catch(error => {
-      emit('error', error)
-    })
+    .catch(error => handleError(emit, error))
 }
 
 function checkValidServiceWorker (swUrl, emit, registrationOptions) {
@@ -95,13 +101,7 @@ function checkValidServiceWorker (swUrl, emit, registrationOptions) {
         registerValidSW(swUrl, emit, registrationOptions)
       }
     })
-    .catch(error => {
-      if (!navigator.onLine) {
-        emit('offline')
-      } else {
-        emit('error', error)
-      }
-    })
+    .catch(error => handleError(emit, error))
 }
 
 export function unregister () {

--- a/src/index.js
+++ b/src/index.js
@@ -44,9 +44,8 @@ export function register (swUrl, hooks = {}) {
 function handleError (emit, error) {
   if (!navigator.onLine) {
     emit('offline')
-  } else {
-    emit('error', error)
   }
+  emit('error', error)
 }
 
 function registerValidSW (swUrl, emit, registrationOptions) {


### PR DESCRIPTION
I'm proposing to extract error handler to get consistent behavior (calling `offline` hook) on localhost and not on localhost.