### PR TITLE
Allow `register` to be called after `onload` event

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -15,6 +15,8 @@ const isLocalhost = () => Boolean(
     )
 )
 
+const waitWindowLoad = new Promise(resolve => window.addEventListener('load', resolve))
+
 export function register (swUrl, hooks = {}) {
   const { registrationOptions = {}} = hooks
   delete hooks.registrationOptions
@@ -26,7 +28,7 @@ export function register (swUrl, hooks = {}) {
   }
 
   if ('serviceWorker' in navigator) {
-    window.addEventListener('load', () => {
+    waitWindowLoad.then(() => {
       if (isLocalhost()) {
         // This is running on localhost. Lets check if a service worker still exists or not.
         checkValidServiceWorker(swUrl, emit, registrationOptions)

--- a/src/index.js
+++ b/src/index.js
@@ -15,7 +15,16 @@ const isLocalhost = () => Boolean(
     )
 )
 
-const waitWindowLoad = new Promise(resolve => window.addEventListener('load', resolve))
+let waitWindowLoad
+// Typically, a browser that supports `serviceWorker` should also have supported
+// `Promise`. But as this package can be used in environments without service
+// worker support (in that case it would do nothing), there's a chance that
+// `Promise` does not exist. So we must check for its existence first.
+if (typeof Promise !== 'undefined') {
+  waitWindowLoad = new Promise(resolve => window.addEventListener('load', resolve))
+} else {
+  waitWindowLoad = { then: (cb) => window.addEventListener('load', cb) }
+}
 
 export function register (swUrl, hooks = {}) {
   const { registrationOptions = {}} = hooks


### PR DESCRIPTION
It's not possible to register service-worker on demand right now.