### PR TITLE
emit 'ready' when service worker is ready

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -36,6 +36,9 @@ export function register (swUrl, hooks = {}) {
       } else {
         // Is not local host. Just register service worker
         registerValidSW(swUrl, emit, registrationOptions)
+        navigator.serviceWorker.ready.then(registration => {
+          emit('ready', registration)
+        })
       }
     })
   }


### PR DESCRIPTION
Emit the 'ready' event regardless of being on localhost development or
in production. When a service worker is active and ready, emit the
signal.

Fixes #20