### PR TITLE
force fetch to get sw filee frm network

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -100,7 +100,7 @@ function registerValidSW (swUrl, emit, registrationOptions) {
 
 function checkValidServiceWorker (swUrl, emit, registrationOptions) {
   // Check if the service worker can be found.
-  fetch(swUrl)
+  fetch(swUrl, {cache: "no-store"})
     .then(response => {
       // Ensure service worker exists, and that we really are getting a JS file.
       if (response.status === 404) {


### PR DESCRIPTION
This enables fetching the service worker config directly frm the network bypassing any http cache.